### PR TITLE
Skip rule checking for empty non required fields

### DIFF
--- a/index.js
+++ b/index.js
@@ -50,7 +50,7 @@ export default class ValidationComponent extends Component {
 
   // Method to check rules on a spefific field
   _checkRules(fieldName, rules, value) {
-    if (!value.length && !rules.required ) { 
+    if (!value && !rules.required ) { 
       return; // if value is empty AND its not required by the rules, no need to check any other rules
     }
     for (const key of Object.keys(rules)) {

--- a/index.js
+++ b/index.js
@@ -50,6 +50,9 @@ export default class ValidationComponent extends Component {
 
   // Method to check rules on a spefific field
   _checkRules(fieldName, rules, value) {
+    if (!value.length && !rules.required ) { 
+      return; // if value is empty AND its not required by the rules, no need to check any other rules
+    }
     for (const key of Object.keys(rules)) {
       const isRuleFn = (typeof this.rules[key] == "function");
       const isRegExp = (this.rules[key] instanceof RegExp);


### PR DESCRIPTION
Issue:
If a field is not required but has another rule associated with it, form validator does not allow to save the form with the said field empty. For e.g. if rules= { 12 : {email:true} } , you cannot save field 12 as empty even though its not required.

Proposed solution:
For every field, before checking all the rules, see if the field value is empty and its not a required field. If yes, no need to check other rules for the field